### PR TITLE
Set origin from circuit-json bounds automatically

### DIFF
--- a/lib/calculateBounds.ts
+++ b/lib/calculateBounds.ts
@@ -41,14 +41,16 @@ export const calculateCircuitBounds = (circuitJson: CircuitJson): Bounds => {
 
   // Calculate bounds from PCB traces
   for (const trace of db.pcb_trace.list()) {
-    const halfWidth = trace.route_thickness_mode === "interpolated"
-      ? 0
-      : (trace.route[0]?.width ?? 0) / 2
+    const halfWidth =
+      trace.route_thickness_mode === "interpolated"
+        ? 0
+        : (trace.route[0]?.width ?? 0) / 2
 
     for (const point of trace.route) {
-      const pointWidth = trace.route_thickness_mode === "interpolated"
-        ? (point.width ?? 0) / 2
-        : halfWidth
+      const pointWidth =
+        trace.route_thickness_mode === "interpolated"
+          ? (point.width ?? 0) / 2
+          : halfWidth
 
       minX = Math.min(minX, point.x - pointWidth)
       minY = Math.min(minY, point.y - pointWidth)
@@ -70,7 +72,12 @@ export const calculateCircuitBounds = (circuitJson: CircuitJson): Bounds => {
   }
 
   // If no elements were found, return a default bounds
-  if (!isFinite(minX) || !isFinite(minY) || !isFinite(maxX) || !isFinite(maxY)) {
+  if (
+    !isFinite(minX) ||
+    !isFinite(minY) ||
+    !isFinite(maxX) ||
+    !isFinite(maxY)
+  ) {
     return { minX: 0, minY: 0, maxX: 0, maxY: 0 }
   }
 
@@ -81,10 +88,14 @@ export const calculateCircuitBounds = (circuitJson: CircuitJson): Bounds => {
  * Calculates the origin needed to shift all elements to the positive quadrant
  * with a small margin
  */
-export const calculateOriginFromBounds = (bounds: Bounds, margin = 0.1): { x: number; y: number } => {
+export const calculateOriginFromBounds = (
+  bounds: Bounds,
+  margin?: number,
+): { x: number; y: number } => {
+  const m = margin ?? 0.1
   // If minimum coordinates are already positive, no shift needed (but add margin)
-  const originX = bounds.minX < margin ? -bounds.minX + margin : 0
-  const originY = bounds.minY < margin ? -bounds.minY + margin : 0
+  const originX = bounds.minX < m ? -bounds.minX + m : 0
+  const originY = bounds.minY < m ? -bounds.minY + m : 0
 
   return { x: originX, y: originY }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,10 @@ import { addPcbTrace } from "./element-handlers/addPcbTrace"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { Polygon, Box, BooleanOperations } from "@flatten-js/core"
 import { polygonToShapePathData } from "./polygon-to-shape-path"
-import { calculateCircuitBounds, calculateOriginFromBounds } from "./calculateBounds"
+import {
+  calculateCircuitBounds,
+  calculateOriginFromBounds,
+} from "./calculateBounds"
 // import { writeDebugSvg } from "./writeDebugSvg"
 
 export const convertCircuitJsonToLbrn = (
@@ -16,6 +19,7 @@ export const convertCircuitJsonToLbrn = (
   options: {
     includeSilkscreen?: boolean
     origin?: { x: number; y: number }
+    margin?: number
   } = {},
 ): LightBurnProject => {
   const db = cju(circuitJson)
@@ -38,7 +42,7 @@ export const convertCircuitJsonToLbrn = (
   let origin = options.origin
   if (!origin) {
     const bounds = calculateCircuitBounds(circuitJson)
-    origin = calculateOriginFromBounds(bounds)
+    origin = calculateOriginFromBounds(bounds, options.margin)
   }
 
   const ctx: ConvertContext = {

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -30,7 +30,9 @@ const originYInput = document.getElementById("originY") as HTMLInputElement
 const includeSilkscreenInput = document.getElementById(
   "includeSilkscreen",
 ) as HTMLInputElement
-const reconvertBtn = document.getElementById("reconvertBtn") as HTMLButtonElement
+const reconvertBtn = document.getElementById(
+  "reconvertBtn",
+) as HTMLButtonElement
 
 // Show error message
 function showError(message: string) {


### PR DESCRIPTION
…drant

When no origin is provided, automatically calculates the bounding box of all circuit elements and sets the origin to ensure all elements are positioned in the positive quadrant (x >= 0, y >= 0). This prevents elements from being cut off in the LightBurn work area which only supports positive coordinates.

- Added calculateBounds.ts with functions to compute circuit bounds
- Modified main conversion to auto-calculate origin when not explicitly provided
- Maintains backward compatibility: explicit origin values are still respected