### PR TITLE
Fix type errors in bounds calculation and UI error handling

### DIFF
--- a/lib/calculateBounds.ts
+++ b/lib/calculateBounds.ts
@@ -41,15 +41,22 @@ export const calculateCircuitBounds = (circuitJson: CircuitJson): Bounds => {
 
   // Calculate bounds from PCB traces
   for (const trace of db.pcb_trace.list()) {
+    const isWidthPoint = (
+      point: (typeof trace.route)[number],
+    ): point is (typeof trace.route)[number] & { width: number } =>
+      "width" in point && typeof point.width === "number"
+
     const halfWidth =
       trace.route_thickness_mode === "interpolated"
         ? 0
-        : (trace.route[0]?.width ?? 0) / 2
+        : (trace.route.find(isWidthPoint)?.width ?? 0) / 2
 
     for (const point of trace.route) {
       const pointWidth =
         trace.route_thickness_mode === "interpolated"
-          ? (point.width ?? 0) / 2
+          ? isWidthPoint(point)
+            ? point.width / 2
+            : 0
           : halfWidth
 
       minX = Math.min(minX, point.x - pointWidth)

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -7,6 +7,12 @@ import type { CircuitJson } from "circuit-json"
 let currentLbrnProject: any = null
 let currentCircuitJson: CircuitJson | null = null
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+
+  return "Unknown error"
+}
+
 // Get DOM elements
 const dropArea = document.getElementById("dropArea") as HTMLDivElement
 const fileInput = document.getElementById("fileInput") as HTMLInputElement
@@ -85,7 +91,7 @@ async function processFile(file: File) {
   } catch (error) {
     showLoading(false)
     console.error("Error processing file:", error)
-    showError(`Error processing file: ${error.message || "Unknown error"}`)
+    showError(`Error processing file: ${getErrorMessage(error)}`)
   }
 }
 
@@ -149,7 +155,7 @@ async function convertAndDisplay() {
   } catch (error) {
     showLoading(false)
     console.error("Error converting:", error)
-    showError(`Error converting: ${error.message || "Unknown error"}`)
+    showError(`Error converting: ${getErrorMessage(error)}`)
   }
 }
 
@@ -215,7 +221,7 @@ downloadBtn.addEventListener("click", () => {
     URL.revokeObjectURL(url)
   } catch (error) {
     console.error("Error downloading file:", error)
-    showError(`Error downloading file: ${error.message || "Unknown error"}`)
+    showError(`Error downloading file: ${getErrorMessage(error)}`)
   }
 })
 


### PR DESCRIPTION
## Summary
- guard PCB trace width calculations to avoid accessing missing properties on vias
- normalize UI error handling to safely extract messages from unknown errors

## Testing
- bunx tsc --noEmit
- bun test tests/svg.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ffa6f6e68832ea0de85e56dc49fc0)