### PR TITLE
fix(bounds): include pcb_hole elements in calculateCircuitBounds

### DIFF
--- a/lib/calculateBounds.ts
+++ b/lib/calculateBounds.ts
@@ -78,6 +78,16 @@ export const calculateCircuitBounds = (circuitJson: CircuitJson): Bounds => {
     }
   }
 
+  // Calculate bounds from unplated holes
+  for (const hole of db.pcb_hole.list()) {
+    const radius = hole.hole_diameter / 2
+
+    minX = Math.min(minX, hole.x - radius)
+    minY = Math.min(minY, hole.y - radius)
+    maxX = Math.max(maxX, hole.x + radius)
+    maxY = Math.max(maxY, hole.y + radius)
+  }
+
   // If no elements were found, return a default bounds
   if (
     !isFinite(minX) ||

--- a/tests/basics/calculate-bounds-pcb-hole.test.ts
+++ b/tests/basics/calculate-bounds-pcb-hole.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { calculateCircuitBounds } from "../../lib/calculateBounds"
+
+test("calculateCircuitBounds includes pcb_hole in bounds", () => {
+  const circuitJson: CircuitJson = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      layer: "top",
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole",
+      hole_shape: "circle",
+      hole_diameter: 2,
+      x: 10,
+      y: 0,
+    },
+  ] as CircuitJson
+
+  const bounds = calculateCircuitBounds(circuitJson)
+
+  // smtpad covers -0.5..0.5; hole covers 9..11
+  expect(bounds.minX).toBeCloseTo(-0.5, 5)
+  expect(bounds.maxX).toBeCloseTo(11, 5)
+  expect(bounds.minY).toBeCloseTo(-1, 5)
+  expect(bounds.maxY).toBeCloseTo(1, 5)
+})
+
+test("calculateCircuitBounds with only pcb_holes returns correct bounds", () => {
+  const circuitJson: CircuitJson = [
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole1",
+      hole_shape: "circle",
+      hole_diameter: 3.2,
+      x: -48,
+      y: -33,
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole2",
+      hole_shape: "circle",
+      hole_diameter: 3.2,
+      x: 48,
+      y: 33,
+    },
+  ] as CircuitJson
+
+  const bounds = calculateCircuitBounds(circuitJson)
+  const r = 1.6
+
+  expect(bounds.minX).toBeCloseTo(-48 - r, 5)
+  expect(bounds.maxX).toBeCloseTo(48 + r, 5)
+  expect(bounds.minY).toBeCloseTo(-33 - r, 5)
+  expect(bounds.maxY).toBeCloseTo(33 + r, 5)
+})


### PR DESCRIPTION
## Summary

`calculateCircuitBounds` looped over smtpads, traces and plated holes but silently skipped `pcb_hole` (unplated mounting holes). When mounting holes were the outermost elements on a board (e.g. corner holes at ±48 mm × ±33 mm) the origin shift produced by `calculateOriginFromBounds` left them outside the laser work area.

Fix: add a loop over `db.pcb_hole.list()` using `hole_diameter / 2` as the radius, matching the pattern already used for `pcb_plated_hole`.

Closes #181

## Changes

- `lib/calculateBounds.ts` — add unplated-hole loop (8 lines)
- `tests/basics/calculate-bounds-pcb-hole.test.ts` — two unit tests covering the exact repro from the issue + corner-hole scenario

## Test plan

- [ ] `bun test tests/basics/calculate-bounds-pcb-hole.test.ts` passes on CI (Linux; sharp unavailable on Windows)
- [ ] `bun test` full suite green