### PR TITLE
Add selector-based LightBurn tooling layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ import { convertCircuitJsonToLbrn } from "circuit-json-to-lbrn"
 const copperLbrn = convertCircuitJsonToLbrn(circuitJson, {
   includeCopper: true,
   includeSoldermask: false,
+  toolingLayerIncludeRefs: [".TP1", ".TP2", ".TP3"],
 })
 
 // Generate soldermask layer only (for cutting polyimide sheet)
@@ -42,6 +43,7 @@ const defaultLbrn = convertCircuitJsonToLbrn(circuitJson)
 - `includeLayers?: Array<"top" | "bottom">` - Specify which layers to include (default: `["top", "bottom"]`)
 - `mirrorBottomLayer?: boolean` - Mirror bottom layer across the board X-center for flipped-board cutting (default: `false`)
 - `includeHolePunch?: boolean` - Include "Hole Punch Top" / "Hole Punch Bottom" layers that mark hole centers for drilling (default: `true`)
+- `toolingLayerIncludeRefs?: string[]` - Copy the PCB copper lands for component selectors such as `".U1"` or `".TP1"` to LightBurn's native, non-output T1 tooling layer (default: `[]`)
 
 ## Soldermask Support
 

--- a/lib/ConvertContext.ts
+++ b/lib/ConvertContext.ts
@@ -24,6 +24,7 @@ export interface ConvertContext {
   topSoldermaskCureCutSetting?: CutSetting
   bottomSoldermaskCureCutSetting?: CutSetting
   reflectedBottomBoardCutSetting?: CutSetting
+  tool1CutSetting?: CutSetting
 
   connMap: ConnectivityMap
 

--- a/lib/createToolingLayerForComponents.ts
+++ b/lib/createToolingLayerForComponents.ts
@@ -1,0 +1,104 @@
+import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+import type { PcbComponent } from "circuit-json"
+import { CutSetting, LightBurnProject, ShapePath } from "lbrnts"
+import type { ConvertContext } from "./ConvertContext"
+import { createCopperShapesForLayer } from "./createCopperShapesForLayer"
+import { addPlatedHole } from "./element-handlers/addPlatedHole"
+import { addSmtPad } from "./element-handlers/addSmtPad"
+
+export const getToolingLayerPcbComponents = ({
+  db,
+  includeLayers,
+  selectors,
+}: {
+  db: CircuitJsonUtilObjects
+  includeLayers: Array<"top" | "bottom">
+  selectors: string[]
+}): PcbComponent[] => {
+  if (selectors.length === 0) return []
+
+  const selectedSourceComponentIds = new Set(
+    selectors
+      .map((selector) => db.source_component.select(selector))
+      .filter((component) => component !== null)
+      .map((component) => component.source_component_id),
+  )
+
+  return db.pcb_component
+    .list()
+    .filter(
+      (component) =>
+        selectedSourceComponentIds.has(component.source_component_id) &&
+        includeLayers.includes(component.layer as "top" | "bottom"),
+    )
+}
+
+export const createToolingLayerForComponents = async ({
+  ctx,
+  pcbComponents,
+}: {
+  ctx: ConvertContext
+  pcbComponents: PcbComponent[]
+}): Promise<void> => {
+  const { tool1CutSetting } = ctx
+  if (!tool1CutSetting || pcbComponents.length === 0) return
+
+  const toolingProject = new LightBurnProject()
+  const ignoredDrillCutSetting = new CutSetting({ index: -1 })
+  const toolingCtx: ConvertContext = {
+    ...ctx,
+    project: toolingProject,
+    topCopperCutSetting: tool1CutSetting,
+    bottomCopperCutSetting: tool1CutSetting,
+    throughBoardCutSetting: ignoredDrillCutSetting,
+    topSoldermaskCutSetting: undefined,
+    bottomSoldermaskCutSetting: undefined,
+    topSoldermaskCureCutSetting: undefined,
+    bottomSoldermaskCureCutSetting: undefined,
+    reflectedBottomBoardCutSetting: undefined,
+    topCutNetGeoms: new Map(),
+    bottomCutNetGeoms: new Map(),
+    topScanNetGeoms: new Map(),
+    bottomScanNetGeoms: new Map(),
+    includeCopper: true,
+    includeSoldermask: false,
+    includeSoldermaskCure: false,
+    topTraceEndpoints: new Set(),
+    bottomTraceEndpoints: new Set(),
+  }
+  const smtPads = ctx.db.pcb_smtpad.list()
+  const platedHoles = ctx.db.pcb_plated_hole.list()
+  const toolingLayers = new Set<"top" | "bottom">()
+
+  for (const component of pcbComponents) {
+    const componentLayer = component.layer as "top" | "bottom"
+    toolingLayers.add(componentLayer)
+    const componentCtx = {
+      ...toolingCtx,
+      includeLayers: [componentLayer],
+    }
+
+    for (const smtPad of smtPads) {
+      if (smtPad.pcb_component_id === component.pcb_component_id) {
+        addSmtPad(smtPad, componentCtx)
+      }
+    }
+
+    for (const platedHole of platedHoles) {
+      if (platedHole.pcb_component_id === component.pcb_component_id) {
+        addPlatedHole(platedHole, componentCtx)
+      }
+    }
+  }
+
+  for (const layer of toolingLayers) {
+    await createCopperShapesForLayer({ layer, ctx: toolingCtx })
+  }
+
+  ctx.project.children.push(
+    ...toolingProject.children.filter(
+      (child): child is ShapePath =>
+        child instanceof ShapePath && child.cutIndex === tool1CutSetting.index,
+    ),
+  )
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,10 @@ import { createCopperShapesForLayer } from "./createCopperShapesForLayer"
 import { createHolePunchLayers } from "./createHolePunchLayers"
 import { createOxidationCleaningLayerForLayer } from "./createOxidationCleaningLayerForLayer"
 import { createSoldermaskCureLayer } from "./createSoldermaskCureLayer"
+import {
+  createToolingLayerForComponents,
+  getToolingLayerPcbComponents,
+} from "./createToolingLayerForComponents"
 import { createTraceClearanceAreasForLayer } from "./createTraceClearanceAreasForLayer"
 import { addPcbBoard } from "./element-handlers/addPcbBoard"
 import { addPcbCutout } from "./element-handlers/addPcbCutout"
@@ -37,6 +41,13 @@ export interface ConvertCircuitJsonToLbrnOptions {
   laserSpotSize?: number
   mirrorBottomLayer?: boolean
   includeHolePunch?: boolean
+  /**
+   * Source component selectors whose PCB copper lands should be copied to
+   * LightBurn's native, non-output T1 tooling layer.
+   *
+   * @example [".U1", ".TP1"]
+   */
+  toolingLayerIncludeRefs?: string[]
   /**
    * Whether to generate copper cut fill layers.
    * Creates a ring/band around traces and pads that will be laser cut
@@ -104,6 +115,12 @@ export const convertCircuitJsonToLbrn = async (
   const includeOxidationCleaningLayer =
     options.includeOxidationCleaningLayer ?? false
   const mirrorBottomLayer = options.mirrorBottomLayer ?? false
+  const toolingLayerIncludeRefs = options.toolingLayerIncludeRefs ?? []
+  const toolingLayerPcbComponents = getToolingLayerPcbComponents({
+    db,
+    includeLayers,
+    selectors: toolingLayerIncludeRefs,
+  })
 
   // Default laser settings
   const defaultCopperSettings = {
@@ -167,6 +184,16 @@ export const convertCircuitJsonToLbrn = async (
     qPulseWidth: boardSettings.pulseWidth,
   })
   project.children.push(throughBoardCutSetting)
+
+  let tool1CutSetting: CutSetting | undefined
+  if (toolingLayerPcbComponents.length > 0) {
+    tool1CutSetting = new CutSetting({
+      type: "Tool",
+      index: LAYER_INDEXES.tool1,
+      name: "T1",
+    })
+    project.children.push(tool1CutSetting)
+  }
 
   let topHolePunchCutSetting: CutSetting | undefined
   let bottomHolePunchCutSetting: CutSetting | undefined
@@ -414,6 +441,7 @@ export const convertCircuitJsonToLbrn = async (
     topSoldermaskCureCutSetting,
     bottomSoldermaskCureCutSetting,
     reflectedBottomBoardCutSetting,
+    tool1CutSetting,
     connMap,
     topCutNetGeoms: new Map(),
     bottomCutNetGeoms: new Map(),
@@ -535,6 +563,11 @@ export const convertCircuitJsonToLbrn = async (
   for (const cutout of db.pcb_cutout.list()) {
     addPcbCutout(cutout, ctx)
   }
+
+  await createToolingLayerForComponents({
+    ctx,
+    pcbComponents: toolingLayerPcbComponents,
+  })
 
   if (shouldIncludeHolePunchLayers) {
     createHolePunchLayers(ctx)

--- a/lib/layer-indexes.ts
+++ b/lib/layer-indexes.ts
@@ -23,6 +23,9 @@ export const LAYER_INDEXES = {
   reflectedBottomBoardCut: 13,
   topHolePunch: 14,
   bottomHolePunch: 15,
+
+  // Native LightBurn non-output tool layers
+  tool1: 30,
 } as const
 
 export type LayerIndex = (typeof LAYER_INDEXES)[keyof typeof LAYER_INDEXES]

--- a/tests/basics/tooling-layer.test.ts
+++ b/tests/basics/tooling-layer.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { CutSetting, ShapePath } from "lbrnts"
+import { convertCircuitJsonToLbrn } from "../../lib"
+import { LAYER_INDEXES } from "../../lib/layer-indexes"
+import circuitJson from "../examples/example02/example02.circuit.json" with {
+  type: "json",
+}
+
+const getToolingShapes = (projectChildren: unknown[]): ShapePath[] =>
+  projectChildren.filter(
+    (child): child is ShapePath =>
+      child instanceof ShapePath && child.cutIndex === LAYER_INDEXES.tool1,
+  )
+
+test("copies selected component copper lands to native LightBurn T1", async () => {
+  const project = await convertCircuitJsonToLbrn(circuitJson as CircuitJson, {
+    origin: { x: 0, y: 0 },
+    includeLayers: ["top"],
+    toolingLayerIncludeRefs: [".TP1"],
+  })
+
+  const toolSetting = project.children.find(
+    (child): child is CutSetting =>
+      child instanceof CutSetting && child.index === LAYER_INDEXES.tool1,
+  )
+  expect(toolSetting).toMatchObject({ type: "Tool", name: "T1" })
+
+  const toolShapes = getToolingShapes(project.children)
+  expect(toolShapes).toHaveLength(1)
+
+  const xs = toolShapes[0]!.verts.map((vertex) => vertex.x)
+  const ys = toolShapes[0]!.verts.map((vertex) => vertex.y)
+  expect(Math.min(...xs)).toBeCloseTo(-2.6)
+  expect(Math.max(...xs)).toBeCloseTo(-1.4)
+  expect(Math.min(...ys)).toBeCloseTo(-0.6)
+  expect(Math.max(...ys)).toBeCloseTo(0.6)
+
+  const xml = project.getString()
+  expect(xml).toContain('<CutSetting type="Tool">')
+  expect(xml).toContain('<index Value="30"/>')
+  expect(xml).toContain('<name Value="T1"/>')
+  expect(xml).toContain('Shape Type="Path" CutIndex="30"')
+})
+
+test("supports multiple ref selectors without changing Circuit JSON", async () => {
+  const inputBeforeConversion = JSON.stringify(circuitJson)
+  const project = await convertCircuitJsonToLbrn(circuitJson as CircuitJson, {
+    origin: { x: 0, y: 0 },
+    includeLayers: ["top"],
+    toolingLayerIncludeRefs: [".TP1", ".TP2", ".TP3"],
+  })
+
+  expect(getToolingShapes(project.children)).toHaveLength(3)
+  expect(JSON.stringify(circuitJson)).toBe(inputBeforeConversion)
+})
+
+test("omits T1 when no refs are requested or selected refs are excluded", async () => {
+  const withoutTooling = await convertCircuitJsonToLbrn(
+    circuitJson as CircuitJson,
+  )
+  const excludedTopRef = await convertCircuitJsonToLbrn(
+    circuitJson as CircuitJson,
+    {
+      includeLayers: ["bottom"],
+      toolingLayerIncludeRefs: [".TP1"],
+    },
+  )
+
+  for (const project of [withoutTooling, excludedTopRef]) {
+    expect(project.getString()).not.toContain('<CutSetting type="Tool">')
+    expect(getToolingShapes(project.children)).toHaveLength(0)
+  }
+})


### PR DESCRIPTION
## Summary

- add a `toolingLayerIncludeRefs` converter option accepting component selectors such as `.U1` and `.TP1`
- copy selected components' existing SMT and plated-hole copper lands to LightBurn's native, non-output T1 layer
- respect component side, `includeLayers`, origin, and bottom-layer mirroring
- create T1 only when an eligible selected component is present
- document the option and add focused selector/tooling coverage

## Why

PR #185 mixed tooling-layer support with new Circuit JSON fabrication-note roles and other fabrication behavior. This extracts the tooling-layer capability without extending or mutating Circuit JSON. Tooling geometry is derived from existing component refs and their PCB copper lands.

## Impact

Callers can add non-output LightBurn guides with:

```ts
convertCircuitJsonToLbrn(circuitJson, {
  toolingLayerIncludeRefs: [".TP1", ".TP2", ".TP3"],
})
```

Normal copper output is unchanged, and the input Circuit JSON remains unchanged.

## Verification

- `bun test` — 76 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`
