### PR TITLE
Use shared manifold-2d runtime

### DIFF
--- a/lib/getManifold.ts
+++ b/lib/getManifold.ts
@@ -1,31 +1,3 @@
-// Lazy-load the manifold WASM module
-// Supports both Node.js and browser environments with CDN fallback
+import { getManifoldModule } from "@tscircuit/manifold-2d"
 
-let manifoldInstance: any = null
-
-export const getManifold = async () => {
-  if (!manifoldInstance) {
-    let ManifoldModule: any
-
-    // Try Node.js import first (for CLI/tests)
-    try {
-      const moduleName = "manifold-3d"
-      ManifoldModule = (await import(/* @vite-ignore */ moduleName)).default
-    } catch {
-      // Fallback to CDN for browser environments
-      try {
-        const cdnUrl =
-          "https://cdn.jsdelivr.net/npm/manifold-3d@3.0.0/manifold.js"
-        ManifoldModule = (await import(/* @vite-ignore */ cdnUrl)).default
-      } catch (cdnError) {
-        throw new Error(
-          `Failed to load manifold-3d: not available in Node.js or via CDN. ${cdnError}`,
-        )
-      }
-    }
-
-    manifoldInstance = await ManifoldModule()
-    manifoldInstance.setup() // Initialize the JS-friendly API
-  }
-  return manifoldInstance
-}
+export const getManifold = async () => getManifoldModule()

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "lbrnts": "^0.0.22",
-    "manifold-3d": "^3.3.2"
+    "@tscircuit/manifold-2d": "^0.0.6",
+    "lbrnts": "^0.0.22"
   }
 }

--- a/tests/manifold-dependency.test.ts
+++ b/tests/manifold-dependency.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import manifoldPackageJson from "../node_modules/@tscircuit/manifold-2d/package.json"
+import packageJson from "../package.json"
+
+test("uses the zero-dependency manifold runtime", () => {
+  expect(packageJson.dependencies["@tscircuit/manifold-2d"]).toBe("^0.0.6")
+  expect("manifold-3d" in packageJson.dependencies).toBe(false)
+
+  const manifoldManifest = manifoldPackageJson as {
+    dependencies?: Record<string, string>
+  }
+  expect(manifoldManifest.dependencies ?? {}).toEqual({})
+})


### PR DESCRIPTION
## Summary

- replace the custom `manifold-3d` dynamic import and jsDelivr fallback with `getManifoldModule()` from `@tscircuit/manifold-2d`
- replace the `manifold-3d` production dependency with `@tscircuit/manifold-2d@^0.0.6`, matching `copper-pour-solver`
- add a dependency regression test that guards against restoring `manifold-3d` and verifies the shared runtime has no production dependencies

## Root cause

`circuit-json-to-lbrn` maintained its own Manifold WASM loading path. That path directly depended on `manifold-3d`, duplicated initialization and caching logic, and used a separately pinned CDN fallback in browser environments. The tscircuit-specific runtime already centralizes Node/browser loading, embeds the browser WASM fallback, calls `setup()`, caches initialization, and avoids `manifold-3d`'s production dependency tree.

## Impact

Manifold geometry operations now use the same zero-dependency shared runtime as `copper-pour-solver`, with consistent behavior in Node and browser bundles.

## Validation

- `bun test --timeout 30000` — 92 passed
- `bun run build`
- `bun run build:site`
- `bun run format:check`
- `git diff --check`